### PR TITLE
The match pattern is now configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Usage
 
 `npm install --save digest-brunch`
 
-Identify assets that you want to be digested with `DIGEST(filename.ext)`.
+Identify assets that you want to be digested with `DIGEST(filename.ext)`, or a custom pattern of your choosing.
 
 ```html
 <!DOCTYPE html>
@@ -60,6 +60,10 @@ exports.config =
   # ...
   plugins:
     digest:
+      # A RegExp where the first subgroup matches the filename to be replaced
+      pattern: /DIGEST\(\/?([^\)]*)\)/g
+      # After replacing the filename, should we discard the non-filename parts of the pattern?
+      discardNonFilenamePatternParts: yes
       # RegExp that matches files that contain DIGEST references.
       referenceFiles: /\.html$/
       # How many digits of the SHA1 to append to digested files.

--- a/test/fixtures/alternate_pattern.html.alt1
+++ b/test/fixtures/alternate_pattern.html.alt1
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Test</title>
+  <script src="**test.js**"></script>
+  <link rel="stylesheet" href="***test.css***">
+</head>
+<body>
+  <script src="****js/nested.js****"></script>
+</body>
+</html>

--- a/test/fixtures/alternate_pattern_no_discard.html.alt2
+++ b/test/fixtures/alternate_pattern_no_discard.html.alt2
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Test</title>
+  <script src="test.js"></script>
+  <link rel="stylesheet" href='test.css'>
+</head>
+<body>
+  <script src="js/nested.js"></script>
+</body>
+</html>


### PR DESCRIPTION
The match pattern is now configurable, as is the decision of whether discard the non-filename parts of the pattern or not.

For backward compatibility, I have set the default pattern to:

```
/DIGEST\((\/?[^\)]*)\)/g
```

…though I argue the default should simply match items in single quotes, double quotes, and within the parentheses of `url(…)`:

```
/(?:['"]|url\(\s*['"]?)(\/?[^'"\)\s]+)(?:['"]|['"]?\s*\))/g
```

That would, of course, be a breaking change.
