### PR TITLE
Option to output digest manifest to JSON file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ exports.config =
       environments: ['production']
       # Prepend an asset host URL to the file paths in the reference files. Use an object e.g. {production: 'http://production-asset-host.co'}
       prependHost: null
+      # Output filename for a JSON manifest of reference file paths and their digest.
+      manifest: ''
 ```
 
 Contributing

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -27,6 +27,8 @@ class Digest
       environments: ['production']
       # Prepend an absolute asset host URL to the file paths in the reference files
       prependHost: null
+      # Output filename for a JSON manifest of reference file paths and their digest.
+      manifest: ''
     }
 
     # Merge config
@@ -59,6 +61,8 @@ class Digest
       filesToDigest = @_filesToDigest(referenceFiles)
       filesAndDigests = @_filesAndDigests(filesToDigest)
       renameMap = @_renameMap(filesAndDigests)
+      if @options.manifest
+        fs.writeFileSync(@options.manifest, JSON.stringify(renameMap, null, 4))
       @_renameAndReplace(referenceFiles, renameMap)
 
   _validDigestFile: (file) ->

--- a/test/index_test.coffee
+++ b/test/index_test.coffee
@@ -281,3 +281,16 @@ describe 'Digest', ->
 
       it 'replaces occurrences of js/nested.js in alternate_pattern_no_discard.html.alt2', ->
         expect(@contents).to.contain "\"#{relativeDigestFilename('js/nested.js')}\""
+
+  describe 'manifest', ->
+    beforeEach ->
+      setupFakeFileSystem()
+
+    it 'outputs a manifest', ->
+      digest.options.manifest = 'public/manifest.json'
+      digest.onCompile()
+      manifest = JSON.parse(fs.readFileSync('public/manifest.json'))
+      expect(Object.keys(manifest)).to.have.length 3
+      expect(manifest['test.js']).to.equal FIXTURES_AND_DIGESTS['test.js']
+      expect(manifest['js/nested.js']).to.equal FIXTURES_AND_DIGESTS['js/nested.js']
+      expect(manifest['test.css']).to.equal FIXTURES_AND_DIGESTS['test.css']


### PR DESCRIPTION
Subsequent build steps could introspect this file, or a server could look up digested file paths to serve. On the path to #8.

---

I say "on the path" because I didn't fully grok the desired changes for #8 once you had the manifest (why what's there "was a bad approach"). I took this simple step because the manifest I was looking for, for my own nefarious purposes, was already in memory as `renameMap`.

So let's discuss how to actually fulfill #8.
