### PR TITLE
Fix issue with paths being incorrect on Windows.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 0.10
+  - 0.12

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -176,7 +176,7 @@ class Digest
       ext = pathlib.extname(path)
       base = pathlib.basename(path, ext)
       newName = "#{base}-#{hash}#{ext}"
-      pathlib.join(dir, newName)
+      pathlib.posix.join(dir, newName)
     else
       path
 
@@ -185,14 +185,14 @@ class Digest
     ext = pathlib.extname(path)
     base = pathlib.basename(path, ext)
     newName = "#{base}#{infix}#{ext}"
-    pathlib.join(dir, newName)
+    pathlib.posix.join(dir, newName)
 
   _writeManifestFile: (renameMap) ->
     if not @options.manifest
       return
     manifest = {}
     for file, hash of renameMap when hash
-      relative = pathlib.relative(@publicFolder, file)
+      relative = pathlib.relative(@publicFolder, file).replace(/\\/g, '/')
       rename = @_addHashToPath relative, hash
       manifest[relative] = rename
     fs.writeFileSync(@options.manifest, JSON.stringify(manifest, null, 4))

--- a/test/index_test.coffee
+++ b/test/index_test.coffee
@@ -17,7 +17,7 @@ FIXTURES_AND_DIGESTS =
 
 digestFilename = (filename) ->
   digest = FIXTURES_AND_DIGESTS[filename] || filename
-  path.join(__dirname, 'public', digest)
+  path.posix.join(__dirname, 'public', digest)
 
 digestFileExists = (filename) ->
   fs.existsSync(digestFilename(filename))
@@ -26,7 +26,7 @@ readDigestFile = (filename) ->
   fs.readFileSync(digestFilename(filename), 'UTF-8')
 
 relativeDigestFilename = (filename) ->
-  path.relative(path.join(__dirname, 'public'), digestFilename(filename))
+  path.posix.relative(path.posix.join(__dirname, 'public'), digestFilename(filename))
 
 loadFixture = (from, to = from) ->
   realContents = realFs.readFileSync("test/fixtures/#{from}").toString()
@@ -103,7 +103,7 @@ describe 'Digest', ->
 
     it 'replaces relative digest urls', ->
       expect(readDigestFile('css/relative.css')).to.contain(
-        path.join('..', relativeDigestFilename('otter.jpeg'))
+        path.posix.join('..', relativeDigestFilename('otter.jpeg'))
       )
 
   describe 'asset host prepending', ->
@@ -345,4 +345,4 @@ describe 'Digest', ->
       )
 
     it 'throws', ->
-      expect(-> digest.onCompile()).to.throw('test/public/circular1.circle')
+      expect(-> digest.onCompile()).to.throw('circular1.circle')


### PR DESCRIPTION
Update to use proper forward slashes for URLs even when run on Windows.

This particular way of implementing the change requires Node 0.12 I believe. If that doesn't work, then we can probably put a shim in or something.